### PR TITLE
A different approach to using pytest hooks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -159,7 +159,8 @@ disable=raw-checker-failed,
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=c-extension-no-member,
+       useless-suppression
 
 
 [BASIC]


### PR DESCRIPTION
I would like to propose an alternative approach to using the pytest hooks. We can use [`pytest_runtest_protocol`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_runtest_protocol) as a generator to completely wrap each test case run. In my opinion, it's the best way to do stuff that needs to happen before and after every test case (like managing coverage measurement). I've also split the report handling into two different hooks. `pytest_runtest_makereport` is in charge of making changes to the report itself, and `pytest_report_teststatus` handles what the user sees. The `pytest_runtest_makereport` hook now also contains the DeFlaker logic. Eventually, we will probably want to carve that off into a separate function too if we decide that we want to modify the report in other ways. Overall, I think this approach has better separation of concerns and is likely to be more extensible.