### PR TITLE
Put back codecov to testing workflows

### DIFF
--- a/.github/workflows/ci-tests-drafts.yaml
+++ b/.github/workflows/ci-tests-drafts.yaml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install -e .[test]
+          pip install pytest pytest-cov
     - name: Test with pytest
       run: |
         pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml

--- a/.github/workflows/ci-tests-drafts.yaml
+++ b/.github/workflows/ci-tests-drafts.yaml
@@ -28,4 +28,9 @@ jobs:
           pip install -e .[test]
     - name: Test with pytest
       run: |
-        pytest -p no:flakefighter --runpytest=subprocess
+        pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v5
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-tests-drafts.yaml
+++ b/.github/workflows/ci-tests-drafts.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install pytest pytest-cov
     - name: Test with pytest
       run: |
-        pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml
+        pytest -p no:flakefighter --runpytest=subprocess --cov=src --cov-report=xml
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -33,4 +33,9 @@ jobs:
           pip install -e .[test]
     - name: Test with pytest
       run: |
-        pytest -p no:flakefighter --runpytest=subprocess
+        pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v5
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -31,6 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install -e .[test]
+          pip install pytest pytest-cov
     - name: Test with pytest
       run: |
         pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           pip install pytest pytest-cov
     - name: Test with pytest
       run: |
-        pytest -p no:flakefighter --runpytest=subprocess --cov=causal_testing --cov-report=xml
+        pytest -p no:flakefighter --runpytest=subprocess --cov=src --cov-report=xml
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
Now that we've made the repo public, I've added back the codecov action to ensure we're testing new code. It can be a bit annoying, but I've found so many bugs by being forced to test :laughing:!