### PR TITLE
Jmafoster1/junitxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ license = {file = "LICENSE"}
 dependencies = [
     "pytest>=6.2.0",
     "coverage>=7.10.6",
-    "GitPython==3.1.45"
+    "GitPython>=3.1.45",
+    "unidiff>=0.7.5",
 ]
 dynamic = ["version"]
 

--- a/src/pytest_flakefighter/plugin.py
+++ b/src/pytest_flakefighter/plugin.py
@@ -38,7 +38,7 @@ class FlakeFighter:
         Stop the coverage measurement after tests are collected.
         :param session: The session.
         """
-        # This line cannot appear as covered on our tests because the coverage measurement is leaking into the self.cov
+        # Line cannot appear as covered on our tests because the coverage measurement is leaking into the self.cov
         self.cov.stop()
 
     @pytest.hookimpl(hookwrapper=True)
@@ -50,7 +50,7 @@ class FlakeFighter:
         :param item: The item.
         """
         self.cov.start()
-        # These lines cannot appear as covered on our tests because the coverage measurement is leaking into the self.cov
+        # Lines cannot appear as covered on our tests because the coverage measurement is leaking into the self.cov
         self.cov.switch_context(item.nodeid)
         yield
         self.cov.stop()

--- a/src/pytest_flakefighter/plugin.py
+++ b/src/pytest_flakefighter/plugin.py
@@ -71,13 +71,14 @@ class FlakeFighter:
         report = outcome.get_result()
         if report.when == "call" and report.failed:
             line_coverage = self.cov.get_data()
-            if not any(
+            flaky = not any(
                 self.line_modified_by_latest_commit(file_path, line_number)
                 for file_path in line_coverage.measured_files()
                 for line_number in line_coverage.lines(file_path)
                 if file_path in self.lines_changed
-            ):
-                report.flaky = True
+            )
+            report.flaky = flaky
+            item.user_properties.append(("flaky", flaky))
         return report
 
     def pytest_report_teststatus(

--- a/src/pytest_flakefighter/plugin.py
+++ b/src/pytest_flakefighter/plugin.py
@@ -24,16 +24,25 @@ class FlakeFighter:
         self.cov = coverage.Coverage()
         self.repo = git.Repo(repo_root if repo_root is not None else ".")
         self.lines_changed = {}
-        self.target_commit = target_commit if target_commit is not None else self.repo.commit().hexsha
-        if source_commit is not None:
-            self.source_commit = source_commit
+        if target_commit is None and not self.repo.is_dirty():
+            # No uncommitted changes, so use most recent commit
+            self.target_commit = self.repo.commit().hexsha
         else:
-            parents = [
-                commit.hexsha
-                for commit in self.repo.commit(source_commit).iter_parents()
-                if commit.hexsha != self.target_commit
-            ]
-            self.source_commit = parents[0]
+            self.target_commit = target_commit
+        if source_commit is None:
+            if self.target_commit is None:
+                # If uncommitted changes, use most recent commit as source
+                self.source_commit = self.repo.commit().hexsha
+            else:
+                # If no uncommitted changes, use previous commit as source
+                parents = [
+                    commit.hexsha
+                    for commit in self.repo.commit(source_commit).iter_parents()
+                    if commit.hexsha != self.target_commit
+                ]
+                self.source_commit = parents[0]
+        else:
+            self.source_commit = source_commit
 
         root = self.repo.git.rev_parse("--show-toplevel")
         patches = PatchSet(self.repo.git.diff(self.source_commit, self.target_commit, "-U0", "--no-prefix"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ def fixture_flaky_triangle_repo(tmpdir_factory):
 
     shutil.copy(os.path.join(CURRENT_DIR, "resources", "triangle_broken.txt"), os.path.join(repo_root, "triangle.py"))
     repo.index.add(["triangle.py"])
-    repo.index.commit("Broke the tests.")
 
     return repo
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,44 +4,46 @@ Define fixtures and plugins.
 
 import os
 import shutil
+from pathlib import Path
 
 import git
 import pytest
 
 # pylint:disable=C0103
 pytest_plugins = "pytester"
+CURRENT_DIR = Path(__file__).parent
 
 
-@pytest.fixture(scope="session", name="flaky_triangle_repo")
+@pytest.fixture(scope="function", name="flaky_triangle_repo")
 def fixture_flaky_triangle_repo(tmpdir_factory):
     """
     Fixture for a minimal git repo with a commit history to hide failing tests.
     """
     repo_root = tmpdir_factory.mktemp("flaky_triangle_repo")
     repo = git.Repo.init(repo_root, initial_branch="main")
-    shutil.copy(os.path.join("tests", "resources", "triangle_example.txt"), os.path.join(repo_root, "triangle.py"))
+
+    shutil.copy(os.path.join(CURRENT_DIR, "resources", "triangle_example.txt"), os.path.join(repo_root, "triangle.py"))
     repo.index.add(["triangle.py"])
     repo.index.commit("Initial commit of test file.")
 
-    shutil.copy(os.path.join("tests", "resources", "triangle_broken.txt"), os.path.join(repo_root, "triangle.py"))
+    shutil.copy(os.path.join(CURRENT_DIR, "resources", "triangle_broken.txt"), os.path.join(repo_root, "triangle.py"))
     repo.index.add(["triangle.py"])
     repo.index.commit("Broke the tests.")
 
-    repo.index.commit("This is an empty commit")
-    return repo_root
+    return repo
 
 
-@pytest.fixture(scope="session", name="deflaker_repo")
+@pytest.fixture(scope="function", name="deflaker_repo")
 def fixture_deflaker_repo(tmpdir_factory):
     """
     Fixture for a minimal git repo with a commit history of broken tests.
     """
     repo_root = tmpdir_factory.mktemp("deflaker_repo")
     repo = git.Repo.init(repo_root, initial_branch="main")
-    shutil.copy(os.path.join("tests", "resources", "deflaker_example.txt"), os.path.join(repo_root, "app.py"))
+    shutil.copy(os.path.join(CURRENT_DIR, "resources", "deflaker_example.txt"), os.path.join(repo_root, "app.py"))
     repo.index.add(["app.py"])
     repo.index.commit("Initial commit of test file.")
-    shutil.copy(os.path.join("tests", "resources", "deflaker_broken.txt"), os.path.join(repo_root, "app.py"))
+    shutil.copy(os.path.join(CURRENT_DIR, "resources", "deflaker_broken.txt"), os.path.join(repo_root, "app.py"))
     repo.index.add(["app.py"])
     repo.index.commit("Broke the tests.")
-    return repo_root
+    return repo

--- a/tests/test_flakefighter.py
+++ b/tests/test_flakefighter.py
@@ -84,12 +84,16 @@ def test_flaky_failures(pytester, flaky_triangle_repo):
 
 
 def test_suppress_flaky_failures(pytester, flaky_triangle_repo):
-    """Make sure that flaky failures are labelled as such"""
+    """Test exit code is OK when only flaky failures"""
 
-    # run pytest with the following cmd args
+    # Add an empty commit to hide the flakiness
+    # Long term, we may want to look at other ways of forcing flaky test outcomes, e.g. random seeds
+    flaky_triangle_repo.index.commit("Broke the tests.")
+    flaky_triangle_repo.index.commit("This is an empty commit")
+
     result = pytester.runpytest(
-        os.path.join(flaky_triangle_repo, "triangle.py"),
-        f"--repo={flaky_triangle_repo}",
+        os.path.join(flaky_triangle_repo.working_dir, "triangle.py"),
+        f"--repo={flaky_triangle_repo.working_dir}",
         "--suppress-flaky-failures-exit-code",
         "-s",
     )
@@ -97,9 +101,9 @@ def test_suppress_flaky_failures(pytester, flaky_triangle_repo):
     result.assert_outcomes(failed=3)
     result.stdout.fnmatch_lines(
         [
-            f"FLAKY {os.path.join('..','flaky_triangle_repo0', 'triangle.py')}::test_eqiulateral*",
-            f"FLAKY {os.path.join('..','flaky_triangle_repo0', 'triangle.py')}::test_isosceles*",
-            f"FLAKY {os.path.join('..','flaky_triangle_repo0', 'triangle.py')}::test_scalene*",
+            f"FLAKY {os.path.join('..',repo_name(flaky_triangle_repo), 'triangle.py')}::test_eqiulateral*",
+            f"FLAKY {os.path.join('..',repo_name(flaky_triangle_repo), 'triangle.py')}::test_isosceles*",
+            f"FLAKY {os.path.join('..',repo_name(flaky_triangle_repo), 'triangle.py')}::test_scalene*",
         ]
     )
     assert result.ret == ExitCode.OK, f"Expected exit code {ExitCode.OK} but was {result.ret}."

--- a/tests/test_flakefighter.py
+++ b/tests/test_flakefighter.py
@@ -4,8 +4,6 @@ Test DeFlaker algorithm.
 
 import os
 
-import git
-
 
 def repo_name(repo):
     return os.path.basename(repo.working_dir)
@@ -30,8 +28,10 @@ def test_real_failures(pytester, flaky_triangle_repo):
     )
 
 
-def test_real_failures_named_source(pytester, flaky_triangle_repo):
+def test_real_failures_named_source_target(pytester, flaky_triangle_repo):
     """Make sure that genuine failures are labelled as such."""
+
+    flaky_triangle_repo.index.commit("Broke the tests.")
 
     # Add an extra commit so we can test indexing from not the most recent
     flaky_triangle_repo.index.commit("This is an empty commit")
@@ -61,6 +61,7 @@ def test_flaky_failures(pytester, flaky_triangle_repo):
 
     # Add an empty commit to hide the flakiness
     # Long term, we may want to look at other ways of forcing flaky test outcomes, e.g. random seeds
+    flaky_triangle_repo.index.commit("Broke the tests.")
     flaky_triangle_repo.index.commit("This is an empty commit")
 
     result = pytester.runpytest(

--- a/tests/test_flakefighter.py
+++ b/tests/test_flakefighter.py
@@ -27,7 +27,7 @@ def test_real_failures(pytester, flaky_triangle_repo):
     result = pytester.runpytest(
         os.path.join(flaky_triangle_repo, "triangle.py"),
         f"--repo={flaky_triangle_repo}",
-        f"--commit={commits[1]}",
+        f"--target-commit={commits[1]}",
         "-s",
     )
 
@@ -44,7 +44,6 @@ def test_real_failures(pytester, flaky_triangle_repo):
 def test_flaky_failures(pytester, flaky_triangle_repo):
     """Make sure that flaky failures are labelled as such"""
 
-    # run pytest with the following cmd args
     result = pytester.runpytest(os.path.join(flaky_triangle_repo, "triangle.py"), f"--repo={flaky_triangle_repo}", "-s")
 
     result.assert_outcomes(failed=3)


### PR DESCRIPTION
Refactored to parse git diffs instead of using logs for individual lines. This allows us to
- Collect changes in advance rather than ad hoc
- Compare local uncommitted changes as well as commit hashes
- Hopefully keep better track of code additions that end up moving lines around